### PR TITLE
bugfix-substituteText type and setters

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -35,20 +35,20 @@ export declare class TextInput extends PIXI.Container {
 
     constructor(options?: TextInputOptions)
 
-    get substituteText(): string
-    substituteText(substitute: string): void
+    get substituteText(): boolean
+    set substituteText(substitute: boolean): void
 
     get placeholder(): string
-    placeholder(text: string): void
+    set placeholder(text: string): void
 
     get disabled(): boolean
-    disabled(n: boolean): void
+    set disabled(n: boolean): void
 
     get maxLength(): number
-    maxLength(length: number): void
+    set maxLength(length: number): void
 
     get restrict(): RegExp
-    restrict(regex: RegExp): void
+    set restrict(regex: RegExp): void
 
     htmlInput(): object
 

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -21,7 +21,7 @@ export declare class TextInput extends PIXI.Container {
     _previous: object
     _dom_added: boolean
     _dom_visible: boolean
-    _dom_input: object
+    _dom_input: HTMLInputElement
     _placeholder: string
     _placeholderColor: number
     _selection: number[]
@@ -50,13 +50,13 @@ export declare class TextInput extends PIXI.Container {
     get restrict(): RegExp
     set restrict(regex: RegExp): void
 
-    htmlInput(): object
+    htmlInput(): HTMLInputElement
 
 
     text(): string
     text(text: string): void
 
-    htmlInput(): object
+    htmlInput(): HTMLInputElement
 
     focus(): void
 


### PR DESCRIPTION
made the setters actually setters (maybe it was my webpack... but it did not like having those without set)

fixed type for substituteText (it is a boolean flag)

MyClass.ts
```typescript
import {TextInput} from 'pixi-textinput-v5'
import * as PIXI from 'pixi.js'

const app = new PIXI.Application({width:400,height:100})
const te = new TextInput({
    input: {
        fontSize: '12px',
        padding: '5px',
        width: '150px',
        color: '#26272E'
    },
    box: {
        default: {fill: 0xE8E9F3, rounded: 1, stroke: {color: 0xCBCEE0, width: 4}},
        focused: {fill: 0xE1E3EE, rounded: 2, stroke: {color: 0x8B8FD6, width: 4}},
        disabled: {fill: 0xDBDBDB, rounded: 2}
    }
});
te.placeholder = "Hello World"
te.substituteText = false;
te.position.x = 25;
te.position.y = 45;
app.stage.addChild(te);
document.body.onload = ()=> {
    document.body.appendChild(app.view)
}
```